### PR TITLE
check if pulseaudio's native-protocol-tcp is loaded

### DIFF
--- a/chromium-armhf
+++ b/chromium-armhf
@@ -6,12 +6,11 @@ addrip="$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gatew
 echo "Enabling XHost Forwarding"
 xhost +local:docker
 
-if pacmd list-modules|grep native-protocol-tcp >/dev/null;then
-  echo Pulseaudio native-protocol-tcp Checked
+echo -n "Pulseaudio native-protocol-tcp: "
+if pactl list modules|grep native-protocol-tcp >/dev/null; then
+  echo Checked
 else
-  echo Loading Pulseaudio native-protocol-tcp module
-  pacmd load-module module-native-protocol-tcp
-  echo Pulseaudio native-protocol-tcp Loaded
+  pactl load-module module-native-protocol-tcp >/dev/null && echo Loaded || echo Failed
 fi
 
 echo "Searching for Docker image ..."

--- a/chromium-armhf
+++ b/chromium-armhf
@@ -6,6 +6,14 @@ addrip="$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gatew
 echo "Enabling XHost Forwarding"
 xhost +local:docker
 
+if pacmd list-modules|grep native-protocol-tcp >/dev/null;then
+  echo Pulseaudio native-protocol-tcp Checked
+else
+  echo Loading Pulseaudio native-protocol-tcp module
+  pacmd load-module module-native-protocol-tcp
+  echo Pulseaudio native-protocol-tcp Loaded
+fi
+
 echo "Searching for Docker image ..."
 DOCKER_IMAGE_ID=$(docker images -q hthiemann/chromium-armhf:latest | head -n 1)
 echo "Found and using ${DOCKER_IMAGE_ID}"


### PR DESCRIPTION
Pulseaudio module native-protocol-tcp is not loaded by default on my system.
I think it would be nice to automatically load it if needed.