### PR TITLE
Set PULSE_COOKIE variable

### DIFF
--- a/chromium-armhf
+++ b/chromium-armhf
@@ -13,7 +13,7 @@ echo "Found and using ${DOCKER_IMAGE_ID}"
 docker run --rm --privileged \
  -e DISPLAY=unix$DISPLAY \
  -e PULSE_SERVER=tcp:${addrip}:4713 \
- -e PULSE_COOKIE_DATA=`pax11publish -d | grep --color=never -Po '(?<=^Cookie: ).*'` \
+ -e PULSE_COOKIE=`COOKIE_FILE="$HOME/.config/pulse/cookie"; COOKIE_FROM_FILE=$(test -f "${COOKIE_FILE}" && xxd -c 256 -p "${COOKIE_FILE}"); test "$(LC_ALL=C pax11publish -d | grep --color=never -Po '(?<=^Cookie: ).*')" != "${COOKIE_FROM_FILE}" && echo ${COOKIE_FROM_FILE}` \
  -v chromium_home:/home \
  -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v /dev:/dev -v /run:/run \


### PR DESCRIPTION
Set PULSE_COOKIE variable to the contents of the $HOME/.config/pulse/cookie
(if exists) if cookie is not equal to the PULSE_COOKIE from X root window
properties. Variable is empty if cookie doesn't exist or if the same cookie
was published to the X server by pulseaudio.